### PR TITLE
Get tests to pass in Python 3

### DIFF
--- a/dataverse/__init__.py
+++ b/dataverse/__init__.py
@@ -1,7 +1,9 @@
+from __future__ import absolute_import
+
 from requests.packages import urllib3
 urllib3.disable_warnings()
 
-from .connection import Connection
-from .dataverse import Dataverse
-from .dataset import Dataset
-from .file import DataverseFile
+from dataverse.connection import Connection
+from dataverse.dataverse import Dataverse
+from dataverse.dataset import Dataset
+from dataverse.file import DataverseFile

--- a/dataverse/connection.py
+++ b/dataverse/connection.py
@@ -1,9 +1,9 @@
 from lxml import etree
 import requests
 
-from dataverse import Dataverse
-import exceptions
-from utils import get_elements
+from .dataverse import Dataverse
+from . import exceptions
+from .utils import get_elements
 
 
 class Connection(object):

--- a/dataverse/connection.py
+++ b/dataverse/connection.py
@@ -1,9 +1,11 @@
+from __future__ import absolute_import
+
 from lxml import etree
 import requests
 
-from .dataverse import Dataverse
-from . import exceptions
-from .utils import get_elements
+from dataverse.dataverse import Dataverse
+from dataverse import exceptions
+from dataverse.utils import get_elements
 
 
 class Connection(object):

--- a/dataverse/dataset.py
+++ b/dataverse/dataset.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import os
 import json
 
@@ -15,9 +17,9 @@ from .exceptions import (
     NoContainerError, OperationFailedError, UnpublishedDataverseError,
     ConnectionError, MetadataNotFoundError, VersionJsonNotFoundError,
 )
-from .file import DataverseFile
-from .settings import SWORD_BOOTSTRAP
-from .utils import get_element, get_files_in_path, add_field
+from dataverse.file import DataverseFile
+from dataverse.settings import SWORD_BOOTSTRAP
+from dataverse.utils import get_element, get_files_in_path, add_field
 
 
 class Dataset(object):

--- a/dataverse/dataset.py
+++ b/dataverse/dataset.py
@@ -1,18 +1,23 @@
 import os
 import json
-import StringIO
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import BytesIO as StringIO
+
 from zipfile import ZipFile
 
 from lxml import etree
 import requests
 
-from exceptions import (
+from .exceptions import (
     NoContainerError, OperationFailedError, UnpublishedDataverseError,
     ConnectionError, MetadataNotFoundError, VersionJsonNotFoundError,
 )
-from file import DataverseFile
-from settings import SWORD_BOOTSTRAP
-from utils import get_element, get_files_in_path, add_field
+from .file import DataverseFile
+from .settings import SWORD_BOOTSTRAP
+from .utils import get_element, get_files_in_path, add_field
 
 
 class Dataset(object):
@@ -35,7 +40,8 @@ class Dataset(object):
         self._id = None
 
         # Updates sword entry from keyword arguments
-        for key, value in kwargs.iteritems():
+        for key in kwargs:
+            value = kwargs[key]
             if isinstance(value, list):
                 for item in value:
                     add_field(self._entry, key, item, 'dcterms')
@@ -271,7 +277,7 @@ class Dataset(object):
             filepaths = get_files_in_path(filepaths[0])
 
         # Zip up files
-        s = StringIO.StringIO()
+        s = StringIO()
         zip_file = ZipFile(s, 'w')
         for filepath in filepaths:
             zip_file.write(filepath)
@@ -282,7 +288,7 @@ class Dataset(object):
 
     def upload_file(self, filename, content, zip_files=True):
         if zip_files:
-            s = StringIO.StringIO()
+            s = StringIO()
             zip_file = ZipFile(s, 'w')
             zip_file.writestr(filename, content)
             zip_file.close()

--- a/dataverse/dataverse.py
+++ b/dataverse/dataverse.py
@@ -1,10 +1,10 @@
 import requests
 
-from dataset import Dataset
-from exceptions import (
+from .dataset import Dataset
+from .exceptions import (
     ConnectionError, MethodNotAllowedError, OperationFailedError,
 )
-from utils import get_element, get_elements, sanitize
+from .utils import get_element, get_elements, sanitize
 
 
 class Dataverse(object):

--- a/dataverse/dataverse.py
+++ b/dataverse/dataverse.py
@@ -1,10 +1,12 @@
+from __future__ import absolute_import
+
 import requests
 
-from .dataset import Dataset
-from .exceptions import (
+from dataverse.dataset import Dataset
+from dataverse.exceptions import (
     ConnectionError, MethodNotAllowedError, OperationFailedError,
 )
-from .utils import get_element, get_elements, sanitize
+from dataverse.utils import get_element, get_elements, sanitize
 
 
 class Dataverse(object):

--- a/dataverse/exceptions.py
+++ b/dataverse/exceptions.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 class DataverseError(Exception):
     """Base exception class for Dataverse-related error."""
     pass

--- a/dataverse/file.py
+++ b/dataverse/file.py
@@ -1,4 +1,4 @@
-from utils import sanitize
+from .utils import sanitize
 
 
 class DataverseFile(object):

--- a/dataverse/file.py
+++ b/dataverse/file.py
@@ -1,4 +1,6 @@
-from .utils import sanitize
+from __future__ import absolute_import
+
+from dataverse.utils import sanitize
 
 
 class DataverseFile(object):

--- a/dataverse/settings/__init__.py
+++ b/dataverse/settings/__init__.py
@@ -1,6 +1,8 @@
-from .defaults import *
+from __future__ import absolute_import
+
+from dataverse.settings.defaults import *
 
 try:
-    from .local import *
+    from dataverse.settings.local import *
 except ImportError as error:
     pass

--- a/dataverse/settings/defaults.py
+++ b/dataverse/settings/defaults.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import os
 
 TEST_HOST = 'apitest.dataverse.org'

--- a/dataverse/test/config.py
+++ b/dataverse/test/config.py
@@ -1,4 +1,7 @@
+from __future__ import absolute_import
+
 import os
+
 from dataverse.settings import BASE_PATH
 
 PICS_OF_CATS_DATASET = {

--- a/dataverse/test/test_dataverse.py
+++ b/dataverse/test/test_dataverse.py
@@ -1,16 +1,16 @@
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import pytest
 
 import uuid
 import httpretty
 
-from ..connection import Connection
-from ..dataset import Dataset
-from ..settings import TEST_HOST, TEST_TOKEN
-from ..test.config import PICS_OF_CATS_DATASET, ATOM_DATASET, EXAMPLE_FILES
-from .. import exceptions
-from .. import utils
+from dataverse.connection import Connection
+from dataverse.dataset import Dataset
+from dataverse.settings import TEST_HOST, TEST_TOKEN
+from dataverse.test.config import PICS_OF_CATS_DATASET, ATOM_DATASET, EXAMPLE_FILES
+from dataverse import exceptions
+from dataverse import utils
 
 import logging
 logging.basicConfig(level=logging.ERROR)

--- a/dataverse/test/test_dataverse.py
+++ b/dataverse/test/test_dataverse.py
@@ -1,14 +1,16 @@
+from __future__ import print_function
+
 import pytest
 
 import uuid
 import httpretty
 
-from dataverse.connection import Connection
-from dataverse.dataset import Dataset
-from dataverse.settings import TEST_HOST, TEST_TOKEN
-from dataverse.test.config import PICS_OF_CATS_DATASET, ATOM_DATASET, EXAMPLE_FILES
-from dataverse import exceptions
-from dataverse import utils
+from ..connection import Connection
+from ..dataset import Dataset
+from ..settings import TEST_HOST, TEST_TOKEN
+from ..test.config import PICS_OF_CATS_DATASET, ATOM_DATASET, EXAMPLE_FILES
+from .. import exceptions
+from .. import utils
 
 import logging
 logging.basicConfig(level=logging.ERROR)
@@ -195,10 +197,10 @@ class TestDatasetOperations(object):
 
     @classmethod
     def setup_class(cls):
-        print 'Connecting to Dataverse host at {0}'.format(TEST_HOST)
+        print('Connecting to Dataverse host at {0}'.format(TEST_HOST))
         cls.connection = Connection(TEST_HOST, TEST_TOKEN)
 
-        print 'Creating test Dataverse'
+        print('Creating test Dataverse')
         cls.alias = str(uuid.uuid1())
         cls.connection.create_dataverse(
             cls.alias,
@@ -211,7 +213,7 @@ class TestDatasetOperations(object):
     @classmethod
     def teardown_class(cls):
 
-        print 'Removing test Dataverse'
+        print('Removing test Dataverse')
         cls.connection.delete_dataverse(cls.dataverse)
         dataverse = cls.connection.get_dataverse(cls.alias, True)
         assert dataverse is None

--- a/dataverse/utils.py
+++ b/dataverse/utils.py
@@ -1,9 +1,11 @@
+from __future__ import absolute_import
+
 import os
 
 from lxml import etree
 import bleach
 
-from .settings import SWORD_NAMESPACE, REPLACEMENT_DICT, UNIQUE_FIELDS
+from dataverse.settings import SWORD_NAMESPACE, REPLACEMENT_DICT, UNIQUE_FIELDS
 
 
 # factor out xpath operations so we don't have to look at its ugliness

--- a/dataverse/utils.py
+++ b/dataverse/utils.py
@@ -3,7 +3,7 @@ import os
 from lxml import etree
 import bleach
 
-from settings import SWORD_NAMESPACE, REPLACEMENT_DICT, UNIQUE_FIELDS
+from .settings import SWORD_NAMESPACE, REPLACEMENT_DICT, UNIQUE_FIELDS
 
 
 # factor out xpath operations so we don't have to look at its ugliness
@@ -15,7 +15,7 @@ def get_element(root, tag='*', namespace=None, attribute=None, attribute_value=N
 def get_elements(root, tag='*', namespace=None, attribute=None, attribute_value=None):
 
     # If string, convert to etree element
-    if isinstance(root, str):
+    if isinstance(root, (str, bytes)):
         root = etree.XML(root)
 
     namespace = root.nsmap.get(namespace, namespace)


### PR DESCRIPTION
A few notes:

* This does not guarantee everything is working in Python 3, only that the tests pass :)

* Some things could be made more elegant by bundling a copy of ``six.py`` which provides a nicer way to have a Python 2 and 3-compatible code base. Other projects such as Astropy do this. If you would be ok with this, I can update this pull request to include this.

* It would be good to set up Travis for continuous integration to make sure that the tests are always run on all supported Python versions - see #19 for more details