### PR TITLE
Update URL from apitest.dataverse.org to demo.dataverse.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - 2.6
   - 2.7
   - 3.3
   #- 3.4 # "No output has been received in the last 10 minutes, this potentially indicates a stalled build or something wrong with the build itself."

--- a/dataverse/file.py
+++ b/dataverse/file.py
@@ -19,6 +19,10 @@ class DataverseFile(object):
 
     @classmethod
     def from_json(cls, dataset, json):
-        name = json['datafile']['name']
-        file_id = json['datafile']['id']
+        try:
+            name = json['dataFile']['filename']
+            file_id = json['dataFile']['id']
+        except KeyError:
+            name = json['datafile']['name']
+            file_id = json['datafile']['id']
         return cls(dataset, name, file_id)

--- a/dataverse/settings/defaults.py
+++ b/dataverse/settings/defaults.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import os
 
-TEST_HOST = 'apitest.dataverse.org'
+TEST_HOST = 'demo.dataverse.org'
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 BASE_PATH = os.path.abspath(os.path.join(HERE, os.pardir))

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ To use the python client, you will need a dataverse account and an API token.
 ```python
 from dataverse import Connection
 
-host = 'apitest.dataverse.org'                  # All clients >4.0 are supported
+host = 'demo.dataverse.org'                  # All clients >4.0 are supported
 token = '4d0634d3-74d5-4770-8088-1971847ac75e'  # Generated at /account/apitoken
 
 connection = Connection(host, token)
@@ -39,7 +39,7 @@ Create a file at `dataverse/settings/local.py`. The file should contain the foll
 information:
 
 ```python
-TEST_HOST = 'apitest.dataverse.org'  # or 'dataverse-demo.iq.harvard.edu'
+TEST_HOST = 'demo.dataverse.org'
 ```
 
 Do not commit this file.


### PR DESCRIPTION
[Issue 36](https://github.com/IQSS/dataverse-client-python/issues/36)
Also, removed reference to dataverse-demo.iq.harvard.edu

To fix failing tests:
To handle new version of dataverse server had to...
Update dataverse/file.py "class class DataverseFile" "def from_json" to accept...
new response format...
json['dataFile']['filename']
json['dataFile']['id']
as well as old...
json['datafile']['name']
json['datafile']['id']

To fix failing test:
dropped python 2.6 from .travis.yml as the latest flake8 requires python >=2.7
flake8 support for 2.6 was dropped at [3.0.0 – 2016-07-25](http://flake8.pycqa.org/en/latest/release-notes/3.0.0.html)