### PR TITLE
Stringify content-length header to fix requests 

### DIFF
--- a/dataverse/dataset.py
+++ b/dataverse/dataset.py
@@ -250,7 +250,7 @@ class Dataset(object):
 
         resp = requests.post(
             self.edit_uri,
-            headers={'In-Progress': 'false', 'Content-Length': 0},
+            headers={'In-Progress': 'false', 'Content-Length': '0'},
             auth=self.connection.auth,
         )
 


### PR DESCRIPTION
## Purpose

Current publishing a Dataverse creates the following error: 
```python
  File "/code/addons/dataverse/client.py", line 76, in publish_dataset
    dataset.publish()
  File "/code/src/dataverse/dataverse/dataset.py", line 254, in publish
    auth=self.connection.auth,
  File "/usr/local/lib/python2.7/site-packages/requests/api.py", line 112, in post
    return request('post', url, data=data, json=json, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/requests/api.py", line 58, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/requests/sessions.py", line 494, in request
    prep = self.prepare_request(req)
  File "/usr/local/lib/python2.7/site-packages/requests/sessions.py", line 437, in prepare_request
    hooks=merge_hooks(request.hooks, self.hooks),
  File "/usr/local/lib/python2.7/site-packages/requests/models.py", line 306, in prepare
    self.prepare_headers(headers)
  File "/usr/local/lib/python2.7/site-packages/requests/models.py", line 440, in prepare_headers
    check_header_validity(header)
  File "/usr/local/lib/python2.7/site-packages/requests/utils.py", line 872, in check_header_validity
    "bytes, not %s" % (name, value, type(value)))
InvalidHeader: Value for header {Content-Length: 0} must be of type str or bytes, not <type 'int'>
``` 

This PR fixes that.

## Changes

- Stringifys content-length header which is invalid
