### PR TITLE
Feature/Nested Dataverse Protocol Key Error

### DIFF
--- a/dataverse/dataset.py
+++ b/dataverse/dataset.py
@@ -98,14 +98,15 @@ class Dataset(object):
             raise NoContainerError('This dataset has not been added to a Dataverse.')
 
         for dataset in self.dataverse.get_contents(refresh=True):
-            doi = '{0}:{1}/{2}'.format(
-                dataset['protocol'],
-                dataset['authority'],
-                dataset['identifier'],
-            )
-            if doi == self.doi:
-                self._id = dataset['id']
-                return self._id
+            if dataset['type'] == 'dataset':
+                doi = '{0}:{1}/{2}'.format(
+                    dataset['protocol'],
+                    dataset['authority'],
+                    dataset['identifier'],
+                )
+                if doi == self.doi:
+                    self._id = dataset['id']
+                    return self._id
 
         raise MetadataNotFoundError('The dataset ID could not be found.')
 

--- a/dataverse/test/test_dataverse.py
+++ b/dataverse/test/test_dataverse.py
@@ -292,6 +292,19 @@ class TestDatasetOperations(DataverseServerTestBase):
         assert retrieved_dataset
         self.dataverse.delete_dataset(retrieved_dataset)
 
+    def test_id_property(self):
+        alias = str(uuid.uuid1())
+        # Creating a dataverse within a dataverse
+        self.connection.create_dataverse(
+            alias,
+            'Sub Dataverse',
+            'dataverse@example.com',
+            self.alias,
+        )
+        sub_dataverse = self.connection.get_dataverse(alias, True)
+        assert self.dataset.id == self.dataset._id
+        self.connection.delete_dataverse(sub_dataverse)
+
     def test_add_files(self):
         self.dataset.upload_filepaths(EXAMPLE_FILES)
         actual_files = [f.name for f in self.dataset.get_files()]


### PR DESCRIPTION
# Purpose

We're getting a Key Error if someone has a nested dataverse inside of a dataverse when connecting a dataset. thanks @felliott for pointing me towards a fix.

# Changes
On the `Dataset.id` property, when looping through the contents of a dataverse, verify that the resource type is a "dataset" before attempting to access the "protocol" key.